### PR TITLE
Use SQLite as default DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database
-DATABASE_URL=postgresql://postgres:password@localhost:5432/contacts_db
+# Default SQLite database. Override to use PostgreSQL or another DB engine.
+DATABASE_URL=sqlite:///./contacts.db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 POSTGRES_DB=contacts_db

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ curl -X DELETE "http://localhost:8000/api/v1/contacts/1"
 
 ```env
 # База даних
-DATABASE_URL=postgresql://postgres:password@localhost:5432/contacts_db
+# За замовчуванням використовується локальна SQLite база.
+# Щоб підключити PostgreSQL або іншу СУБД, змініть значення `DATABASE_URL`.
+DATABASE_URL=sqlite:///./contacts.db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 POSTGRES_DB=contacts_db

--- a/app/database.py
+++ b/app/database.py
@@ -10,7 +10,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # URL підключення до бази даних
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:password@localhost:5432/contacts_db")
+# За замовчуванням використовується локальна SQLite база. Для підключення до
+# PostgreSQL або іншої СУБД необхідно перевизначити змінну середовища
+# `DATABASE_URL` у файлі `.env`.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./contacts.db")
 
 # Створення engine для підключення до БД
 engine = create_engine(DATABASE_URL)


### PR DESCRIPTION
## Summary
- default to a SQLite database in `app/database.py`
- document overriding `DATABASE_URL` in `.env.example`
- update README to mention SQLite default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f171d4090832aa90c66ea21c279be